### PR TITLE
Add 'click' event type to examples

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -18,6 +18,15 @@
         "infra",
         "test"
       ]
+    },
+    {
+      "login": "jonathantneal",
+      "name": "Jonathan Neal",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/188426?v=4",
+      "profile": "http://jonathantneal.com",
+      "contributions": [
+        "doc"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![downloads][downloads-badge]][npmtrends]
 [![MIT License][license-badge]][LICENSE]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Code of Conduct][coc-badge]][coc]
 [![Babel Macro][macros-badge]][babel-macros]
@@ -162,8 +162,8 @@ here!
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/import-all.macro/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/import-all.macro/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/import-all.macro/commits?author=kentcdodds "Tests") |
-| :---: |
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/import-all.macro/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/import-all.macro/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/import-all.macro/commits?author=kentcdodds "Tests") | [<img src="https://avatars0.githubusercontent.com/u/188426?v=4" width="100px;"/><br /><sub>Jonathan Neal</sub>](http://jonathantneal.com)<br />[📖](https://github.com/kentcdodds/import-all.macro/commits?author=jonathantneal "Documentation") |
+| :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Here are a few before/after examples:
 ```javascript
 import importAll from 'import-all.macro'
 
-document.getElementById('load-stuff').addEventListener(() => {
+document.getElementById('load-stuff').addEventListener('click', () => {
   importAll('./my-files/*.js').then(all => {
     console.log(all)
   })
@@ -71,7 +71,7 @@ document.getElementById('load-stuff').addEventListener(() => {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-document.getElementById('load-stuff').addEventListener(() => {
+document.getElementById('load-stuff').addEventListener('click', () => {
   Promise.all([
     import('./my-files/a.js'),
     import('./my-files/b.js'),

--- a/src/__tests__/__snapshots__/macro.js.snap
+++ b/src/__tests__/__snapshots__/macro.js.snap
@@ -4,7 +4,7 @@ exports[`README:1 \`importAll\` uses dynamic import 1`] = `
 
 import importAll from 'import-all.macro'
 
-document.getElementById('load-stuff').addEventListener(() => {
+document.getElementById('load-stuff').addEventListener('click', () => {
   importAll('./my-files/*.js').then(all => {
     console.log(all)
   })
@@ -12,7 +12,7 @@ document.getElementById('load-stuff').addEventListener(() => {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-document.getElementById('load-stuff').addEventListener(() => {
+document.getElementById('load-stuff').addEventListener('click', () => {
   Promise.all([
     import('./my-files/a.js'),
     import('./my-files/b.js'),

--- a/src/__tests__/macro.js
+++ b/src/__tests__/macro.js
@@ -36,7 +36,7 @@ pluginTester({
     'README:1 `importAll` uses dynamic import': `
       import importAll from '../macro'
 
-      document.getElementById('load-stuff').addEventListener(() => {
+      document.getElementById('load-stuff').addEventListener('click', () => {
         importAll('./fixtures/*.js').then(all => {
           console.log(all)
         })


### PR DESCRIPTION
Used other/snap-to-readme.js to update the README.md.

**What**: A fix to the example of `addEventListener` so that it includes the event type.

**Why**: Because the `addEventListener` function requires the first argument to be a type.

**How**: By updating the snap files that included the examples with the type.

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

Two things.

1. I refrained from committing a “forced error”, which is a formatting change to package.json that was caused by installing and running scripts in the project. This change formats the `description` and `files` fields. I’m happy to submit this as a separate PR.

2. I might recommend that scripts, like the `other/snap-to-readme.js` script that I needed to use, be made into npm commands. I’m happy to submit this as a separate PR.