### PR TITLE
Fix macro detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
   "dependencies": {
-    "babel-macros": "^1.0.2",
+    "babel-macros": "^1.2.0",
     "glob": "^7.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
**What**:
Updates `babel-macros` to at least 1.2.0 (the current version).

**Why**:
Previous version of `babel-macros` causes `import-all.macro` to break because of this change in v. 1.0.3: **improve macro detection** (https://github.com/kentcdodds/babel-macros/commit/945c8eb).