### PR TITLE
feat: provide options to transform module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,51 +145,18 @@ const routes = importAll.deferred('./files/*.js')
       ↓ ↓ ↓ ↓ ↓ ↓
 
 const routes = {
-  './files/a.js': function() {
+  './files/a.js': function () {
     return import('./files/a.js')
   },
-  './files/b.js': function() {
+  './files/b.js': function () {
     return import('./files/b.js')
   },
-  './files/c.js': function() {
+  './files/c.js': function () {
     return import('./files/c.js')
   },
-  './files/d.js': function() {
+  './files/d.js': function () {
     return import('./files/d.js')
   },
-}
-```
-
-**Configure `importAll` to transform import path before generating imports**
-
-`babel-plugin-macros.config.js`:
-
-```javascript
-module.exports = {
-  importAll: {
-    transformModulePath(modulePath) {
-      return modulePath.replace(/\.js$/, '')
-    },
-  },
-}
-```
-
-```javascript
-import importAll from 'import-all.macro'
-
-const a = importAll.sync('./files/*.js')
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import * as _filesA from './files/a'
-import * as _filesB from './files/b'
-import * as _filesC from './files/c'
-import * as _filesD from './files/d'
-const a = {
-  './files/a': _filesA,
-  './files/b': _filesB,
-  './files/c': _filesC,
-  './files/d': _filesD,
 }
 ```
 
@@ -248,6 +215,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,36 @@ const routes = {
 
 <!-- SNAP_TO_README:END -->
 
+**Configure `importAll` to transform import path before generating imports**
+
+`babel-plugin-macros.config.js`:
+
+```javascript
+module.exports = {
+  importAll: {
+    transformModulePath(modulePath) {
+      return modulePath.replace(/\.js$/, '')
+    },
+  },
+}
+```
+
+```javascript
+import importAll from 'import-all.macro'
+const a = importAll.sync('./files/*.js')
+      ↓ ↓ ↓ ↓ ↓ ↓
+import * as _filesA from './files/a'
+import * as _filesB from './files/b'
+import * as _filesC from './files/c'
+import * as _filesD from './files/d'
+const a = {
+  './files/a': _filesA,
+  './files/b': _filesB,
+  './files/c': _filesC,
+  './files/d': _filesD,
+}
+```
+
 ## Caveats
 
 Some static analysis tools (like ESLint, Flow, and Jest) wont like this very

--- a/README.md
+++ b/README.md
@@ -169,8 +169,15 @@ const routes = {
 ```javascript
 module.exports = {
   importAll: {
-    transformModulePath(modulePath) {
-      return modulePath.replace(/\.js$/, '')
+    transformModulePath(modulePath, importingPath) {
+      const projectRoot = path.join(__dirname, '../../')
+      const modulePathWithoutExt = modulePath.replace(/\.js$/, '')
+      const absolutePath = path.resolve(
+        path.dirname(importingPath),
+        modulePathWithoutExt,
+      )
+      const pathRelativeToRoot = path.relative(projectRoot, absolutePath)
+      return pathRelativeToRoot
     },
   },
 }

--- a/README.md
+++ b/README.md
@@ -160,6 +160,39 @@ const routes = {
 }
 ```
 
+**Configure `importAll` to transform import path before generating imports**
+
+`babel-plugin-macros.config.js`:
+
+```javascript
+module.exports = {
+  importAll: {
+    transformModulePath(modulePath) {
+      return modulePath.replace(/\.js$/, '')
+    },
+  },
+}
+```
+
+```javascript
+import importAll from 'import-all.macro'
+
+const a = importAll.sync('./files/*.js')
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import * as _filesA from './files/a'
+import * as _filesB from './files/b'
+import * as _filesC from './files/c'
+import * as _filesD from './files/d'
+const a = {
+  './files/a': _filesA,
+  './files/b': _filesB,
+  './files/c': _filesC,
+  './files/d': _filesD,
+}
+```
+
 <!-- SNAP_TO_README:END -->
 
 ## Caveats

--- a/src/__tests__/__snapshots__/macro-transform-import.js.snap
+++ b/src/__tests__/__snapshots__/macro-transform-import.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`macros README:4 configure \`importAll\` to transform import path before generating imports: README:4 configure \`importAll\` to transform import path before generating imports 1`] = `
+
+import importAll from 'import-all.macro'
+
+const a = importAll.sync('./files/*.js')
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import * as _filesA from './files/a'
+import * as _filesB from './files/b'
+import * as _filesC from './files/c'
+import * as _filesD from './files/d'
+const a = {
+  './files/a': _filesA,
+  './files/b': _filesB,
+  './files/c': _filesC,
+  './files/d': _filesD,
+}
+
+
+`;

--- a/src/__tests__/__snapshots__/macro-transform-import.js.snap
+++ b/src/__tests__/__snapshots__/macro-transform-import.js.snap
@@ -8,15 +8,15 @@ const a = importAll.sync('./files/*.js')
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import * as _filesA from './files/a'
-import * as _filesB from './files/b'
-import * as _filesC from './files/c'
-import * as _filesD from './files/d'
+import * as _src__tests__FixturesA from 'src/__tests__/files/a'
+import * as _src__tests__FixturesB from 'src/__tests__/files/b'
+import * as _src__tests__FixturesC from 'src/__tests__/files/c'
+import * as _src__tests__FixturesD from 'src/__tests__/files/d'
 const a = {
-  './files/a': _filesA,
-  './files/b': _filesB,
-  './files/c': _filesC,
-  './files/d': _filesD,
+  'src/__tests__/files/a': _src__tests__FixturesA,
+  'src/__tests__/files/b': _src__tests__FixturesB,
+  'src/__tests__/files/c': _src__tests__FixturesC,
+  'src/__tests__/files/d': _src__tests__FixturesD,
 }
 
 

--- a/src/__tests__/helpers/create-macro-test.js
+++ b/src/__tests__/helpers/create-macro-test.js
@@ -22,7 +22,7 @@ export function createMacroTests(pluginTesterOptions) {
   pluginTester({
     snapshot: true,
     formatResult(result) {
-      return prettier.format(result, prettierConfig)
+      return prettier.format(result, {...prettierConfig, parser: 'babel'})
     },
     ...pluginTesterOptions,
   })

--- a/src/__tests__/helpers/create-macro-test.js
+++ b/src/__tests__/helpers/create-macro-test.js
@@ -1,0 +1,33 @@
+import path from 'path'
+import pluginTester from 'babel-plugin-tester'
+import prettier from 'prettier'
+import {prettier as prettierConfig} from 'kcd-scripts/config'
+
+const projectRoot = path.join(__dirname, '../../../').replace(/\\/g, '/')
+
+expect.addSnapshotSerializer({
+  print(val) {
+    return val
+      .split(projectRoot)
+      .join('<PROJECT_ROOT>/')
+      .replace(/fixtures/g, 'files')
+      .replace(/..\/macro/, 'import-all.macro')
+  },
+  test(val) {
+    return typeof val === 'string'
+  },
+})
+
+export function createMacroTests(pluginTesterOptions) {
+  pluginTester({
+    snapshot: true,
+    babelOptions: {
+      filename: __filename,
+    },
+    formatResult(result) {
+      return prettier.format(result, prettierConfig)
+    },
+    ...pluginTesterOptions,
+  })
+}
+

--- a/src/__tests__/helpers/create-macro-test.js
+++ b/src/__tests__/helpers/create-macro-test.js
@@ -21,13 +21,9 @@ expect.addSnapshotSerializer({
 export function createMacroTests(pluginTesterOptions) {
   pluginTester({
     snapshot: true,
-    babelOptions: {
-      filename: __filename,
-    },
     formatResult(result) {
       return prettier.format(result, prettierConfig)
     },
     ...pluginTesterOptions,
   })
 }
-

--- a/src/__tests__/macro-transform-import.js
+++ b/src/__tests__/macro-transform-import.js
@@ -1,13 +1,21 @@
+import path from 'path'
 import plugin from 'babel-plugin-macros'
 
-import { createMacroTests } from './helpers/create-macro-test'
+import {createMacroTests} from './helpers/create-macro-test'
 
 createMacroTests({
   plugin: (babel, options) => {
     return plugin(babel, {
       importAll: {
-        transformModulePath(modulePath) {
-          return modulePath.replace(/\.js$/, '')
+        transformModulePath(modulePath, importingPath) {
+          const projectRoot = path.join(__dirname, '../../')
+          const modulePathWithoutExt = modulePath.replace(/\.js$/, '')
+          const absolutePath = path.resolve(
+            path.dirname(importingPath),
+            modulePathWithoutExt,
+          )
+          const pathRelativeToRoot = path.relative(projectRoot, absolutePath)
+          return pathRelativeToRoot
         },
       },
       ...options,

--- a/src/__tests__/macro-transform-import.js
+++ b/src/__tests__/macro-transform-import.js
@@ -1,0 +1,26 @@
+import plugin from 'babel-plugin-macros'
+
+import { createMacroTests } from './helpers/create-macro-test'
+
+createMacroTests({
+  plugin: (babel, options) => {
+    return plugin(babel, {
+      importAll: {
+        transformModulePath(modulePath) {
+          return modulePath.replace(/\.js$/, '')
+        },
+      },
+      ...options,
+    })
+  },
+  babelOptions: {
+    filename: __filename,
+  },
+  tests: {
+    'README:4 configure `importAll` to transform import path before generating imports': `
+      import importAll from '../macro'
+
+      const a = importAll.sync('./fixtures/*.js')
+    `,
+  },
+})

--- a/src/__tests__/macro.js
+++ b/src/__tests__/macro.js
@@ -1,32 +1,11 @@
-import path from 'path'
-import pluginTester from 'babel-plugin-tester'
 import plugin from 'babel-plugin-macros'
-import prettier from 'prettier'
-import {prettier as prettierConfig} from 'kcd-scripts/config'
 
-const projectRoot = path.join(__dirname, '../../').replace(/\\/g, '/')
+import { createMacroTests } from './helpers/create-macro-test'
 
-expect.addSnapshotSerializer({
-  print(val) {
-    return val
-      .split(projectRoot)
-      .join('<PROJECT_ROOT>/')
-      .replace(/fixtures/g, 'files')
-      .replace(/..\/macro/, 'import-all.macro')
-  },
-  test(val) {
-    return typeof val === 'string'
-  },
-})
-
-pluginTester({
+createMacroTests({
   plugin,
-  snapshot: true,
   babelOptions: {
     filename: __filename,
-  },
-  formatResult(result) {
-    return prettier.format(result, prettierConfig)
   },
   tests: {
     'no usage': `import importAll from '../macro'`,


### PR DESCRIPTION
before generating import statements

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->

**Why**:

To resolve the problem described in #24 

<!-- How were these changes implemented? -->

**How**:

Provide an option in `babel-plugin-macros.config.js` to transform module path before generating import expressions.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
